### PR TITLE
Update info.json

### DIFF
--- a/info.json
+++ b/info.json
@@ -3,8 +3,8 @@
     "name": "News Cast",
     "version": "1.0.0",
     "description": "Erhalte aktuelle Nachrichten auf dein Glancr und spiegel diese in deiner Smartphone App",
-    "module_url": "https://glancr.de/module/...", // TODO
-    "download_url": "https://api.glancr.de/update/moduleZips/..", // TODO
+    "module_url": "https://glancr.de/module/...",
+    "download_url": "https://api.glancr.de/update/moduleZips/..",
     "category": "News",
     "last_update": "YYYY-MM-DD"
   },


### PR DESCRIPTION
Comments are not valid in JSON, so PHP's json_decode fails and mirr.OS cannot show module metadata.